### PR TITLE
feat: 마이페이지 공동구매글 조회 API 구현

### DIFF
--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/GroupPurchaseParticipant.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/GroupPurchaseParticipant.java
@@ -2,15 +2,7 @@ package com.team573.gongguri.domain.groupPurchase.entity;
 
 import com.team573.gongguri.domain.member.entity.Member;
 import com.team573.gongguri.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +24,7 @@ public class GroupPurchaseParticipant extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Enum<ParticipationStatus> participationStatus;
+    private ParticipationStatus participationStatus;
 }

--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/ParticipationStatus.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/ParticipationStatus.java
@@ -1,4 +1,6 @@
 package com.team573.gongguri.domain.groupPurchase.entity;
 
 public enum ParticipationStatus {
+    JOINED,
+    CANCELLED
 }

--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/repository/GroupPurchaseParticipantRepository.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/repository/GroupPurchaseParticipantRepository.java
@@ -1,0 +1,11 @@
+package com.team573.gongguri.domain.groupPurchase.repository;
+
+import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchaseParticipant;
+import com.team573.gongguri.domain.groupPurchase.entity.ProgressStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupPurchaseParticipantRepository extends JpaRepository<GroupPurchaseParticipant, Long> {
+    List<GroupPurchaseParticipant> findByMember_MemberIdAndGroupPurchase_ProgressStatus(Long memberId, ProgressStatus progressStatus);
+}

--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/repository/GroupPurchaseRepository.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/repository/GroupPurchaseRepository.java
@@ -1,7 +1,13 @@
 package com.team573.gongguri.domain.groupPurchase.repository;
 
 import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchase;
+import com.team573.gongguri.domain.groupPurchase.entity.ProgressStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Long> {
+    List<GroupPurchase> findByMember_MemberIdAndProgressStatus(Long memberId, ProgressStatus status);
+
+    List<GroupPurchase> findByMember_MemberId(Long memberId);
 }

--- a/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageRestController.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageRestController.java
@@ -1,0 +1,41 @@
+package com.team573.gongguri.domain.myPage.controller;
+
+import com.team573.gongguri.domain.groupPurchase.dto.GroupPurchaseResponseDto;
+import com.team573.gongguri.domain.myPage.service.MyPageService;
+import com.team573.gongguri.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/my-page")
+public class MyPageRestController {
+    private final MyPageService myPageService;
+
+    // 내가 작성한 공구글 조회
+    @GetMapping("/created")
+    public ResponseEntity<List<GroupPurchaseResponseDto>> getMyCreatedPurchases(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "ALL") String status) {
+        Long memberId = userDetails.getMemberId();
+        return ResponseEntity.ok(myPageService.findMyCreatedPurchases(memberId,status));
+    }
+
+    // 내가 참여한 공구글 조회
+    @GetMapping("/participated")
+    public ResponseEntity<List<GroupPurchaseResponseDto>> getMyParticipatedPurchases(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        return ResponseEntity.ok(myPageService.findMyParticipatedPurchases(memberId));
+    }
+
+
+}

--- a/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
@@ -1,0 +1,28 @@
+package com.team573.gongguri.domain.myPage.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/my-page")
+public class MyPageViewController {
+
+    @GetMapping("")
+    public String showMyPageForm() {
+        return "/my-page/main";
+    }
+
+    @GetMapping("/profile")
+    public String showMyProfileForm() {
+        return "/my-page/profile";
+    }
+
+    @GetMapping("/purchase")
+    public String showLoginForm() {
+        return "/my-page/purchase";
+    }
+
+}

--- a/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
@@ -21,7 +21,7 @@ public class MyPageViewController {
     }
 
     @GetMapping("/purchase")
-    public String showLoginForm() {
+    public String showMyPurchaseForm() {
         return "/my-page/purchase";
     }
 

--- a/src/main/java/com/team573/gongguri/domain/myPage/service/MyPageService.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/service/MyPageService.java
@@ -1,0 +1,57 @@
+package com.team573.gongguri.domain.myPage.service;
+
+import com.team573.gongguri.domain.groupPurchase.dto.GroupPurchaseResponseDto;
+import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchase;
+import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchaseParticipant;
+import com.team573.gongguri.domain.groupPurchase.entity.ProgressStatus;
+import com.team573.gongguri.domain.groupPurchase.mapper.GroupPurchaseMapper;
+import com.team573.gongguri.domain.groupPurchase.repository.GroupPurchaseParticipantRepository;
+import com.team573.gongguri.domain.groupPurchase.repository.GroupPurchaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+    private final GroupPurchaseRepository groupPurchaseRepository;
+    private final GroupPurchaseParticipantRepository groupPurchaseParticipantRepository;
+
+    // 내가 작성한 공구글
+    public List<GroupPurchaseResponseDto> findMyCreatedPurchases(Long memberId, String statusFilter){
+
+        ProgressStatus status = null;
+
+        if( !statusFilter.equals("ALL") ){
+            status = ProgressStatus.valueOf(statusFilter);
+        }
+
+        List<GroupPurchase> purchases;
+        if(status != null) { // 'ALL'
+            purchases = groupPurchaseRepository.findByMember_MemberIdAndProgressStatus(memberId, status);
+        }else{
+            purchases = groupPurchaseRepository.findByMember_MemberId(memberId);
+        }
+
+        return purchases.stream()
+                .map(GroupPurchaseMapper::toDto)
+                .toList();
+    }
+
+    // 내가 참여한 공구글
+    public List<GroupPurchaseResponseDto> findMyParticipatedPurchases(Long memberId){
+
+        // '본인이 참여했으며, 연관된 공구가 완료된' 공구 참여자 entity 조회
+        List<GroupPurchaseParticipant> participants =
+                groupPurchaseParticipantRepository.findByMember_MemberIdAndGroupPurchase_ProgressStatus(
+                        memberId, ProgressStatus.COMPLETED);
+
+        // 필터링 entity 로부터 공구글 추출, DTO 변환
+        return participants.stream()
+                .map(GroupPurchaseParticipant::getGroupPurchase)
+                .map(GroupPurchaseMapper::toDto)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/team573/gongguri/global/security/CustomUserDetails.java
+++ b/src/main/java/com/team573/gongguri/global/security/CustomUserDetails.java
@@ -33,4 +33,9 @@ public class CustomUserDetails implements UserDetails {
     public String getNickname() {
         return member.getNickname();
     }
+
+    public Long getMemberId() {
+        return member.getMemberId();
+    }
+
 }

--- a/src/main/java/com/team573/gongguri/global/security/SecurityConfig.java
+++ b/src/main/java/com/team573/gongguri/global/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                         .loginPage("/login")
                         .loginProcessingUrl("/login")
                         .usernameParameter("email") // 파라미터를 email로 지정
-                        .defaultSuccessUrl("/", true)
+                        .defaultSuccessUrl("/groupPurchase", true)
                         .permitAll()
                 )
                 .logout(logout -> logout


### PR DESCRIPTION
## 🛠️ 작업 내용
본인이 작성한 글 조회 API
참여했던 공동구매 글 조회 API
   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 파일 혹은 폴더명 수정

## 🔗 관련 이슈
#13 

## 💬 기타 참고 사항
Postman 통해서 API 테스트 완료하였습니다.
(각각 status, 작성자 값을 바꿔보며 정상작동하는지 확인했습니다.)
테스트 편의를 위해 JSON형태로 반환했습니다. 뷰 구현하면서 Model 기준으로 controller 수정하도록 하겠습니다.

1.  **참가자 상태 ENUM 수정하였습니다.**
```
public enum ParticipationStatus {
    JOINED,
    CANCELLED
}
```

2. **`GroupPurchaseParticipantRepository` 생성하였습니다.**

3.  **본인이 작성한 글에 대해서는 status 필터링이 가능합니다. (값이 없으면 모두 검색합니다.)**
 `UserDetails`를 통해 본인의 정보를 가져옵니다.
```   
@GetMapping("/created")
    public ResponseEntity<List<GroupPurchaseResponseDto>> getMyCreatedPurchases(
            @AuthenticationPrincipal CustomUserDetails userDetails,
            @RequestParam(defaultValue = "ALL") String status) {
        Long memberId = userDetails.getMemberId();
        return ResponseEntity.ok(myPageService.findMyCreatedPurchases(memberId,status));
    }
```
4. **참여한 공동구매 글에 대해서는 완료된(`COMPLETED`) 값만 반환합니다.**
 마찬가지로 `UserDetails`를 통해 본인의 정보를 가져옵니다.
```
    @GetMapping("/participated")
    public ResponseEntity<List<GroupPurchaseResponseDto>> getMyParticipatedPurchases(
            @AuthenticationPrincipal CustomUserDetails userDetails
    ) {
        Long memberId = userDetails.getMemberId();
        return ResponseEntity.ok(myPageService.findMyParticipatedPurchases(memberId));
    }
```
