### PR TITLE
feat: memberId로 프로필 조회 기능 및 뷰 구현

### DIFF
--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/PurchaseFilter.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/entity/PurchaseFilter.java
@@ -1,0 +1,7 @@
+package com.team573.gongguri.domain.groupPurchase.entity;
+
+public enum PurchaseFilter {
+    ALL,
+    ONGOING,
+    COMPLETED
+}

--- a/src/main/java/com/team573/gongguri/domain/groupPurchase/service/GroupPurchaseService.java
+++ b/src/main/java/com/team573/gongguri/domain/groupPurchase/service/GroupPurchaseService.java
@@ -10,6 +10,7 @@ import com.team573.gongguri.domain.groupPurchase.dto.GroupPurchaseWithParticipan
 import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchase;
 import com.team573.gongguri.domain.groupPurchase.entity.GroupPurchaseParticipant;
 import com.team573.gongguri.domain.groupPurchase.entity.ProgressStatus;
+import com.team573.gongguri.domain.groupPurchase.entity.PurchaseFilter;
 import com.team573.gongguri.domain.groupPurchase.mapper.GroupPurchaseMapper;
 import com.team573.gongguri.domain.groupPurchase.mapper.GroupPurchaseParticipantMapper;
 import com.team573.gongguri.domain.groupPurchase.repository.GroupPurchaseParticipantRepository;
@@ -191,4 +192,30 @@ public class GroupPurchaseService {
     public GroupPurchaseSimpleResponseDto getSimpleInfo(Long groupPurchaseId) {
         return groupPurchaseJpqlRepository.getSimple(groupPurchaseId);
     }
-}
+
+    //특정 멤버가 작성한 공동구매글 조회
+    public List<GroupPurchaseResponseDto> findCreatedPurchases(Long memberId, PurchaseFilter purchaseFilter){
+
+        List<GroupPurchase> purchases;
+        switch (purchaseFilter) {
+            case ONGOING -> {
+                List<ProgressStatus> statuses = List.of(ProgressStatus.RECRUITING, ProgressStatus.CLOSED);
+                purchases = groupPurchaseRepository.findByMember_MemberIdAndProgressStatusIn(memberId, statuses);
+            }
+            case COMPLETED -> {
+                purchases = groupPurchaseRepository.findByMember_MemberIdAndProgressStatus(memberId, ProgressStatus.COMPLETED);
+            }
+            default -> {
+                purchases = groupPurchaseRepository.findByMember_MemberId(memberId);
+            }
+        }
+
+        return purchases.stream()
+                .map(purchase -> {
+                    int currentParticipants = participantRepository.countByGroupPurchase_GroupId(purchase.getGroupId());
+                    return GroupPurchaseMapper.toDto(purchase, currentParticipants, false);
+                })
+                .toList();
+    }
+
+    }

--- a/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/controller/MyPageViewController.java
@@ -1,6 +1,8 @@
 package com.team573.gongguri.domain.myPage.controller;
 
 import com.team573.gongguri.domain.groupPurchase.dto.GroupPurchaseResponseDto;
+import com.team573.gongguri.domain.groupPurchase.entity.PurchaseFilter;
+import com.team573.gongguri.domain.groupPurchase.service.GroupPurchaseService;
 import com.team573.gongguri.domain.myPage.service.MyPageService;
 import com.team573.gongguri.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import java.util.List;
 @RequestMapping("/my-page")
 public class MyPageViewController {
     private final MyPageService myPageService;
+    private final GroupPurchaseService groupPurchaseService;
 
     @GetMapping("")
     public String showMyPageForm(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -26,19 +29,19 @@ public class MyPageViewController {
     }
 
     @GetMapping("/profile")
-    public String showProfile(
+    public String showMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "ALL") String status,
+            @RequestParam(defaultValue = "ALL") PurchaseFilter status,
             Model model) {
 
         model.addAttribute("nickname", userDetails.getNickname());
         Long memberId = userDetails.getMemberId();
 
         // 내 작성 공동구매 리스트 조회
-        List<GroupPurchaseResponseDto> createdList = myPageService.findMyCreatedPurchases(memberId, status);
+        List<GroupPurchaseResponseDto> createdList = groupPurchaseService.findCreatedPurchases(memberId, status);
 
         // 뷰에 상태와 리스트 전달
-        model.addAttribute("status", status);
+        model.addAttribute("status", status.name());
         model.addAttribute("createdList", createdList);
 
         return "myPage/profile";

--- a/src/main/java/com/team573/gongguri/domain/myPage/service/MyPageService.java
+++ b/src/main/java/com/team573/gongguri/domain/myPage/service/MyPageService.java
@@ -15,33 +15,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
-    private final GroupPurchaseRepository groupPurchaseRepository;
+
     private final GroupPurchaseParticipantRepository groupPurchaseParticipantRepository;
-
-    // 내가 작성한 공구글
-    public List<GroupPurchaseResponseDto> findMyCreatedPurchases(Long memberId, String statusFilter){
-
-        List<GroupPurchase> purchases;
-        switch (statusFilter) {
-            case "ONGOING" -> {
-                List<ProgressStatus> statuses = List.of(ProgressStatus.RECRUITING, ProgressStatus.CLOSED);
-                purchases = groupPurchaseRepository.findByMember_MemberIdAndProgressStatusIn(memberId, statuses);
-            }
-            case "COMPLETED" -> {
-                purchases = groupPurchaseRepository.findByMember_MemberIdAndProgressStatus(memberId, ProgressStatus.COMPLETED);
-            }
-            default -> {
-                purchases = groupPurchaseRepository.findByMember_MemberId(memberId);
-            }
-        }
-
-        return purchases.stream()
-                .map(purchase -> {
-                    int currentParticipants = groupPurchaseParticipantRepository.countByGroupPurchase_GroupId(purchase.getGroupId());
-                    return GroupPurchaseMapper.toDto(purchase, currentParticipants, false);
-                })
-                .toList();
-    }
 
     // 내가 참여한 공구글
     public List<GroupPurchaseResponseDto> findMyParticipatedPurchases(Long memberId){

--- a/src/main/java/com/team573/gongguri/domain/profile/controller/ProfileViewController.java
+++ b/src/main/java/com/team573/gongguri/domain/profile/controller/ProfileViewController.java
@@ -1,0 +1,45 @@
+package com.team573.gongguri.domain.profile.controller;
+
+import com.team573.gongguri.domain.groupPurchase.dto.GroupPurchaseResponseDto;
+import com.team573.gongguri.domain.groupPurchase.entity.PurchaseFilter;
+import com.team573.gongguri.domain.groupPurchase.service.GroupPurchaseService;
+import com.team573.gongguri.domain.member.entity.Member;
+import com.team573.gongguri.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/profile")
+public class ProfileViewController {
+    private final GroupPurchaseService groupPurchaseService;
+    private final MemberRepository memberRepository;
+
+    //특정 멤버 id로 멤버 프로필 조회
+    @GetMapping("/{memberId}")
+    public String showMyProfile(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "ALL") PurchaseFilter status,
+            Model model) {
+
+        Member member = memberRepository.findById(memberId).orElse(null);
+        model.addAttribute("nickname", member.getNickname());
+        model.addAttribute("memberId", memberId);
+
+        // 유저 작성 공동구매 리스트 조회
+        List<GroupPurchaseResponseDto> createdList = groupPurchaseService.findCreatedPurchases(memberId, status);
+
+        // 뷰에 상태와 리스트 전달
+        model.addAttribute("status", status.name());
+        model.addAttribute("createdList", createdList);
+
+        return "profile/profile";
+    }
+}

--- a/src/main/resources/templates/profile/profile.html
+++ b/src/main/resources/templates/profile/profile.html
@@ -13,7 +13,7 @@
 <div th:replace="~{fragments/layout :: mobileContainer}">
     <div th:fragment="content">
 
-        <div th:replace="~{fragments/topbar :: topBar('마이페이지')}"></div>
+        <div th:replace="~{fragments/topbar :: topBar('프로필 조회')}"></div>
 
         <main class="container">
 
@@ -24,16 +24,16 @@
                 </div>
             </section>
 
-            <h3 class="section-title">내 게시물</h3>
+            <h3 class="section-title">게시물</h3>
 
             <div class="status-filter">
-                <a th:href="@{/my-page/profile(status='ALL')}"
+                <a th:href="@{|/profile/${memberId}?status=ALL|}"
                    th:class="${status} == 'ALL' ? 'filter-btn selected' : 'filter-btn'">전체</a>
 
-                <a th:href="@{/my-page/profile(status='ONGOING')}"
+                <a th:href="@{|/profile/${memberId}?status=ONGOING|}"
                    th:class="${status} == 'ONGOING' ? 'filter-btn selected' : 'filter-btn'">진행중</a>
 
-                <a th:href="@{/my-page/profile(status='COMPLETED')}"
+                <a th:href="@{|/profile/${memberId}?status=COMPLETED|}"
                    th:class="${status} == 'COMPLETED' ? 'filter-btn selected' : 'filter-btn'">완료</a>
             </div>
 


### PR DESCRIPTION
## 🛠️ 작업 내용
memberId로 프로필 조회 기능 및 뷰 구현
   
## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## 🔗 관련 이슈
- #30 

## 💬 기타 참고 사항

### 검색용 필터링 ENUM 클래스
검색 조건용 enum 클래스를 추가하였습니다. 
해당 클래스를 사용하도록 리팩토링 진행해주시면 됩니다.
```
public enum PurchaseFilter {
    ALL,
    ONGOING,
    COMPLETED
}
```
### 타인의 프로필 조회 뷰
memberId 기준으로 조회 가능합니다.
![image](https://github.com/user-attachments/assets/389c7364-66e1-4563-b4ae-fb2918074a87)

### 기타 코드 이동
memberId를 조건으로 공동구매글을 검색하는 메서드가 범용적으로 쓰임에 따라,
GroupPurchaseService로 기능을 이관하였습니다.
```
    //특정 멤버가 작성한 공동구매글 조회
    public List<GroupPurchaseResponseDto> findCreatedPurchases(Long memberId, PurchaseFilter purchaseFilter){

```